### PR TITLE
 Add a blog post about persistent sentinel metric data in InfluxDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ If you want your component to appear here, send a pull request to this repositor
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)
 - [Sentinel一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
-- [Sentinel控制台监控数据持久化【MySQL】](https://www.cnblogs.com/cdfive2018/p/9838577.html) by [cdfive](https://github.com/cdfive)
+- [Sentinel控制台监控数据持久化【MySQL】(Spring Data JPA)](https://www.cnblogs.com/cdfive2018/p/9838577.html) by [cdfive](https://github.com/cdfive)

--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@ If you want your component to appear here, send a pull request to this repositor
 ## Tutorials
 
 ## Samples / Demos
+- [sentinel-zuul-example](https://github.com/tigerMoon/sentinel-zuul-sample): A simple project integration Sentinel to Spring Cloud Zuul which provide Service and API Path level flow control management by [tiger](https://github.com/tigerMoon)
 
 ## Extensions / Integrations
-
 - [sentinel-support](https://github.com/cdfive/sentinel-support): A support project for convenient Sentinel integration including properties file configuration, ActiveMQ integration and a JdbcDataSource implementation.
 
 ## Blogs
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)
 - [Sentinel一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
+- [Sentinel 一体化监控解决方案 CrateDB + Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
+- [在生产环境中使用 Sentinel 控制台](https://github.com/alibaba/Sentinel/wiki/%E5%9C%A8%E7%94%9F%E4%BA%A7%E7%8E%AF%E5%A2%83%E4%B8%AD%E4%BD%BF%E7%94%A8-Sentinel-%E6%8E%A7%E5%88%B6%E5%8F%B0) by [Eric Zhao](https://github.com/sczyh30)
+- [限流降级神器-哨兵(Sentinel)原理分析](https://mp.weixin.qq.com/s/7_pCkamNv0269e5l9_Wz7w) by [houyi](https://github.com/all4you)
+- [限流降级神器-哨兵(Sentinel)的资源调用链原理分析](https://mp.weixin.qq.com/s/UEzwD22YC6jpp02foNSXnw)  by [houyi](https://github.com/all4you)
 - [Sentinel控制台监控数据持久化【MySQL】(Spring Data JPA)](https://www.cnblogs.com/cdfive2018/p/9838577.html) by [cdfive](https://github.com/cdfive)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ If you want your component to appear here, send a pull request to this repositor
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)
 - [Sentinel一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
-- [Sentinel 一体化监控解决方案 CrateDB + Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
 - [在生产环境中使用 Sentinel 控制台](https://github.com/alibaba/Sentinel/wiki/%E5%9C%A8%E7%94%9F%E4%BA%A7%E7%8E%AF%E5%A2%83%E4%B8%AD%E4%BD%BF%E7%94%A8-Sentinel-%E6%8E%A7%E5%88%B6%E5%8F%B0) by [Eric Zhao](https://github.com/sczyh30)
 - [限流降级神器-哨兵(Sentinel)原理分析](https://mp.weixin.qq.com/s/7_pCkamNv0269e5l9_Wz7w) by [houyi](https://github.com/all4you)
 - [限流降级神器-哨兵(Sentinel)的资源调用链原理分析](https://mp.weixin.qq.com/s/UEzwD22YC6jpp02foNSXnw)  by [houyi](https://github.com/all4you)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want your component to appear here, send a pull request to this repositor
 
 ## Extensions / Integrations
 
-- [sentinel-support](https://github.com/cdfive/sentinel-support): A support project for convenient sentinel integration.
+- [sentinel-support](https://github.com/cdfive/sentinel-support): A support project for convenient Sentinel integration including properties file configuration, ActiveMQ integration and a JdbcDataSource implementation.
 
 ## Blogs
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ If you want your component to appear here, send a pull request to this repositor
 
 ## Extensions / Integrations
 
+- [sentinel-support](https://github.com/cdfive/sentinel-support): A support project for convenient sentinel integration.
+
 ## Blogs
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ If you want your component to appear here, send a pull request to this repositor
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)
 - [Sentinel一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
-- [Sentinel控制台监控数据持久化【MySQL】] (https://www.cnblogs.com/cdfive2018/p/9838577.html) by [cdfive](https://github.com/cdfive)
+- [Sentinel控制台监控数据持久化【MySQL】](https://www.cnblogs.com/cdfive2018/p/9838577.html) by [cdfive](https://github.com/cdfive)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want your component to appear here, send a pull request to this repositor
 ## Blogs
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)
-- [Sentinel 一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
+- [Sentinel 一体化监控解决方案 CrateDB + Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
 - [在生产环境中使用 Sentinel 控制台](https://github.com/alibaba/Sentinel/wiki/%E5%9C%A8%E7%94%9F%E4%BA%A7%E7%8E%AF%E5%A2%83%E4%B8%AD%E4%BD%BF%E7%94%A8-Sentinel-%E6%8E%A7%E5%88%B6%E5%8F%B0) by [Eric Zhao](https://github.com/sczyh30)
 - [限流降级神器-哨兵(Sentinel)原理分析](https://mp.weixin.qq.com/s/7_pCkamNv0269e5l9_Wz7w) by [houyi](https://github.com/all4you)
 - [限流降级神器-哨兵(Sentinel)的资源调用链原理分析](https://mp.weixin.qq.com/s/UEzwD22YC6jpp02foNSXnw)  by [houyi](https://github.com/all4you)

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ If you want your component to appear here, send a pull request to this repositor
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)
 - [Sentinel一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
+- [Sentinel控制台监控数据持久化【MySQL】] (https://www.cnblogs.com/cdfive2018/p/9838577.html) by [cdfive](https://github.com/cdfive)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ If you want your component to appear here, send a pull request to this repositor
 ## Blogs
 
 - [Sentinel 为 Dubbo 服务保驾护航](http://dubbo.apache.org/zh-cn/blog/sentinel-introduction-for-dubbo.html) by [Eric Zhao](https://github.com/sczyh30)
-- [Sentinel一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
+- [Sentinel 一体化监控解决方案 CrateDB+Grafana](https://blog.csdn.net/huyong1990/article/details/82392386) by [Young Hu](https://github.com/YoungHu)
 - [在生产环境中使用 Sentinel 控制台](https://github.com/alibaba/Sentinel/wiki/%E5%9C%A8%E7%94%9F%E4%BA%A7%E7%8E%AF%E5%A2%83%E4%B8%AD%E4%BD%BF%E7%94%A8-Sentinel-%E6%8E%A7%E5%88%B6%E5%8F%B0) by [Eric Zhao](https://github.com/sczyh30)
 - [限流降级神器-哨兵(Sentinel)原理分析](https://mp.weixin.qq.com/s/7_pCkamNv0269e5l9_Wz7w) by [houyi](https://github.com/all4you)
 - [限流降级神器-哨兵(Sentinel)的资源调用链原理分析](https://mp.weixin.qq.com/s/UEzwD22YC6jpp02foNSXnw)  by [houyi](https://github.com/all4you)
 - [Sentinel 控制台监控数据持久化【MySQL】(Spring Data JPA)](https://www.cnblogs.com/cdfive2018/p/9838577.html) by [cdfive](https://github.com/cdfive)
 - [限流降级神器-哨兵(Sentinel)基于滑动时间窗口的实时指标统计分析](https://mp.weixin.qq.com/s/B1_7Kb_CxeKEAv43kdCWOA)  by [houyi](https://github.com/all4you)
 - [Sentinel学习笔记（1）-- 流量统计代码解析](https://www.jianshu.com/p/7936d7a57924)  by [ro9er](https://github.com/ro9er)
-- [Sentinel控制台监控数据持久化【InfluxDB】](https://www.cnblogs.com/cdfive2018/p/9914838.html) by [cdfive](https://github.com/cdfive)
+- [Sentinel 控制台监控数据持久化【InfluxDB】](https://www.cnblogs.com/cdfive2018/p/9914838.html) by [cdfive](https://github.com/cdfive)


### PR DESCRIPTION
使用InfluxDB实现Sentinel控制台的MetricsRepository接口存储和查询metrics数据，记录分享学习过程。